### PR TITLE
feat: alby api for lightning side of gateway

### DIFF
--- a/gateway/ln-gateway/src/alby.rs
+++ b/gateway/ln-gateway/src/alby.rs
@@ -1,0 +1,163 @@
+use std::fmt;
+use std::str::FromStr;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use fedimint_core::task::{sleep, TaskGroup};
+use fedimint_core::Amount;
+use fedimint_ln_common::route_hints::RouteHint;
+use fedimint_ln_common::PrunedInvoice;
+use secp256k1::PublicKey;
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use tokio::sync::mpsc;
+use tonic::Status;
+use tracing::info;
+
+use crate::gateway_lnrpc::{
+    EmptyResponse, GetNodeInfoResponse, GetRouteHintsResponse, InterceptHtlcRequest,
+    InterceptHtlcResponse, PayInvoiceRequest, PayInvoiceResponse,
+};
+use crate::lnrpc_client::{
+    ILnRpcClient, LightningRpcError, RouteHtlcStream, MAX_LIGHTNING_RETRIES,
+};
+
+type HtlcSubscriptionSender = mpsc::Sender<Result<InterceptHtlcRequest, Status>>;
+
+const LND_PAYMENT_TIMEOUT_SECONDS: i32 = 180;
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+struct AlbyPayResponse {
+    amount: u64,
+    description: String,
+    destination: String,
+    fee: u64,
+    payment_hash: Vec<u8>,
+    payment_preimage: Vec<u8>,
+    payment_request: String,
+}
+
+pub struct GatewayAlbyClient {
+    /// LND client
+    listen_address: String,
+    api_key: String,
+}
+
+impl GatewayAlbyClient {
+    pub async fn new(listen_address: String, api_key: String) -> Self {
+        info!("Gateway configured to connect to Alby at \n address: {listen_address:?}");
+        GatewayAlbyClient {
+            listen_address,
+            api_key,
+        }
+    }
+}
+
+impl fmt::Debug for GatewayAlbyClient {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "AlbyClient")
+    }
+}
+
+#[async_trait]
+impl ILnRpcClient for GatewayAlbyClient {
+    /// Returns the public key of the lightning node to use in route hint
+    ///
+    /// What should we do here with Alby?
+    /// - Is the pubkey always the same?
+    /// - Could change to optional: If Custodial API, hardcode the pubkey for
+    ///   the node
+    async fn info(&self) -> Result<GetNodeInfoResponse, LightningRpcError> {
+        let mainnet = "mainnet";
+        let alias = "getalby.com";
+        let pub_key = PublicKey::from_str(
+            "030a58b8653d32b99200a2334cfe913e51dc7d155aa0116c176657a4f1722677a3",
+        )
+        .unwrap();
+        let pub_key = pub_key.serialize().to_vec();
+
+        return Ok(GetNodeInfoResponse {
+            pub_key: pub_key,
+            alias: alias.to_string(),
+            network: mainnet.to_string(),
+        });
+    }
+
+    /// We can probably just use the Alby node pubkey here?
+    /// SCID is the short channel ID mapping to the federation
+    async fn routehints(
+        &self,
+        num_route_hints: usize,
+    ) -> Result<GetRouteHintsResponse, LightningRpcError> {
+        todo!()
+        // Ok(GetRouteHintsResponse { route_hints })
+    }
+
+    /// Pay an invoice using the alby api
+    /// Pay needs to be idempotent, this is why we need lookup payment,
+    /// would need to do something similar with Alby
+    async fn pay(
+        &self,
+        request: PayInvoiceRequest,
+    ) -> Result<PayInvoiceResponse, LightningRpcError> {
+        let client = reqwest::Client::new();
+        let endpoint = "https://api.getalby.com/payments/bolt11";
+
+        let req = json!({
+            "invoice": request.invoice,
+        });
+
+        let response = client
+            .post(endpoint)
+            .header("Authorization", format!("Bearer {}", self.api_key))
+            .json(&req)
+            .send()
+            .await
+            .unwrap();
+
+        let response = response.json::<AlbyPayResponse>().await.unwrap();
+
+        Ok(PayInvoiceResponse {
+            preimage: response.payment_preimage,
+        })
+    }
+
+    // FIXME: deduplicate implementation with pay
+    async fn pay_private(
+        &self,
+        invoice: PrunedInvoice,
+        max_delay: u64,
+        max_fee: Amount,
+    ) -> Result<PayInvoiceResponse, LightningRpcError> {
+        todo!()
+
+        // Ok(PayInvoiceResponse { preimage })
+    }
+
+    /// Returns true if the lightning backend supports payments without full
+    /// invoices
+    fn supports_private_payments(&self) -> bool {
+        false
+    }
+
+    /// TODO: For receiving payments, we need to implement a webhook
+    async fn route_htlcs<'a>(
+        self: Box<Self>,
+        task_group: &mut TaskGroup,
+    ) -> Result<(RouteHtlcStream<'a>, Arc<dyn ILnRpcClient>), LightningRpcError> {
+        todo!()
+        // Ok((Box::pin(ReceiverStream::new(gateway_receiver)), new_client))
+    }
+
+    /// TODO: For receiving payments, we need to implement a webhook
+    async fn complete_htlc(
+        &self,
+        htlc: InterceptHtlcResponse,
+    ) -> Result<EmptyResponse, LightningRpcError> {
+        todo!()
+
+        // Err(LightningRpcError::FailedToCompleteHtlc {
+        //     failure_reason: "Gatewayd has not started to route
+        // HTLCs".to_string(), })
+    }
+}

--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod alby;
 pub mod client;
 pub mod db;
 pub mod lnd;


### PR DESCRIPTION
This implements the PAY side of the lightning gateway using the Alby API, with no changes alby side.

To implement the RECEIVE side, we'd have to implement a webhook or htlc interceptor form the alby side. See `route_htlcs` and `complete_htlc`.

Pending Questions:

1. Is the receiver pubkey for any alby invoice always the `030a58b8653d32b99200a2334cfe913e51dc7d155aa0116c176657a4f1722677a3` aliased to getalby.com? If that changes, we'd need a way to get that through the alby api, but from my hitting get invoice and hitting a bunch of different getalby.com lightning addresses it looks like it's always that one

2. There's a couple nuances about private payments that are worth discussing and depend on Alby's API architecture

3. Are Alby pay requests via the API idemompotent? If not we have to use `check_status` so the gateway doeesn't try to pay the invoice twice. I think we can use the existing GET status endpoints for this but it's redundant to do so if the pay API is idempotent.